### PR TITLE
Add background subtraction...subtraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+.history*
 MANIFEST
 
 # PyInstaller

--- a/bulk_euclid/external_targets/pipeline.py
+++ b/bulk_euclid/external_targets/pipeline.py
@@ -264,6 +264,8 @@ def download_all_data_at_tile_index(cfg: OmegaConf, tile_index: int) -> dict:
     for _, flux_tile in flux_tile_metadata.iterrows():
         dict_of_locs[flux_tile["filter_name"]] = {"FLUX": flux_tile["file_loc"]}  # will add other keys laters
 
+    if cfg.add_bkg and 'MERBKG' not in cfg.auxillary_products:
+        cfg.auxillary_products.append('MERBKG')  # add BKG if not already requested
 
     # also download all auxillary data for that tile
     if cfg.auxillary_products == []:
@@ -521,6 +523,13 @@ def save_jpg_cutout(cfg: OmegaConf, target_data: dict, save_loc: str):
         j_im: np.ndarray = target_data['NIR_J']['FLUX'].data
     else:
         j_im = None
+
+    if cfg.add_bkg:
+        vis_im = vis_im + target_data['VIS']['MERBKG'].data
+        if y_im is not None:
+            y_im = y_im + target_data['NIR_Y']['MERBKG'].data
+        if j_im is not None:
+            j_im = j_im + target_data['NIR_J']['MERBKG'].data
 
     expected_save_locs = [save_loc.replace('generic', output_format) for output_format in cfg.jpg_outputs]
     logging.debug(expected_save_locs)

--- a/bulk_euclid/mer_catalog_targets/a_make_catalogs_and_cutouts.py
+++ b/bulk_euclid/mer_catalog_targets/a_make_catalogs_and_cutouts.py
@@ -135,6 +135,12 @@ def download_tile_and_catalog(cfg, tiles_to_download: pd.DataFrame, tile_index: 
     for band in cfg.bands:
         tile_metadata_to_copy[f'{band.lower()}_loc'] = downloaded_tiles.query(f'filter_name == "{band}"')['file_loc'].squeeze()
 
+        if cfg.add_bkg:
+            mosaic_product_oid = downloaded_tiles.query(f'tile_index == {tile_index} & filter_name == "{band}"')['mosaic_product_oid']
+            bkg_tiles = pipeline_utils.get_auxillary_tiles(mosaic_product_oid.iloc[0], auxillary_products = ['MERBKG'])
+            bkg_tile_loc = bkg_tiles.iloc[0]['datalabs_path'] + '/' + bkg_tiles.iloc[0]['file_name']
+            tile_metadata_to_copy[f'{band.lower()}_bkg_loc'] = bkg_tile_loc
+
     tile_catalog = get_and_save_tile_catalog(cfg, tile_index, tile_metadata_to_copy)
     return tile_catalog
 

--- a/bulk_euclid/utils/pipeline_utils.py
+++ b/bulk_euclid/utils/pipeline_utils.py
@@ -126,9 +126,13 @@ def find_relevant_sources_in_tile(cfg, tile_index: int) -> pd.DataFrame:
     if cfg.sas_environment == 'IDR':
         vis_flux_col = 'flux_vis_1fwhm_aper'  # now renamed with 1FWHM etc
         ext_cols = ''  # not yet available
+    elif cfg.sas_environment == 'PDR':
+        vis_flux_col = 'flux_vis_1fwhm_aper'
+        ext_cols = ', flux_g_ext_decam_1fwhm_aper, flux_i_ext_decam_1fwhm_aper, flux_r_ext_decam_1fwhm_aper'
     else:
         vis_flux_col = 'flux_vis_aper'
         ext_cols = ', flux_g_ext_decam_aper, flux_i_ext_decam_aper, flux_r_ext_decam_aper'
+        
     query_str = f"""
     SELECT object_id, right_ascension, declination, gaia_id, segmentation_area, flux_segmentation, flux_detection_total, {vis_flux_col}, mumax_minus_mag, mu_max, ellipticity, kron_radius, segmentation_map_id {ext_cols}
     FROM catalogue.mer_catalogue
@@ -295,6 +299,9 @@ def save_cutouts(cfg, tile_galaxies: pd.DataFrame):
     tile_data = {}
     for band in cfg.bands:
         tile_data[band] = fits.getdata(tile_galaxies[f'{band.lower()}_loc'].iloc[0], header=False, memmap=False, decompress_in_memory=True)
+        if cfg.add_bkg:
+            bkg_data = fits.getdata(tile_galaxies[f'{band.lower()}_bkg_loc'].iloc[0], header=False, memmap=False, decompress_in_memory=True)
+            tile_data[band] = tile_data[band] + bkg_data
     header = fits.getheader(tile_galaxies[f'{cfg.bands[0].lower()}_loc'].iloc[0])
     # vis_loc = tile_galaxies['vis_tile'].iloc[0]
     # nisp_loc = tile_galaxies['y_tile'].iloc[0]

--- a/configs/mer_catalog_targets/example_config.yaml
+++ b/configs/mer_catalog_targets/example_config.yaml
@@ -9,6 +9,7 @@ max_retries: 1  # retry failed tile downloads
 selection_cuts: galaxy_zoo  # or lens_candidates
 base_dir: '/media/home/my_workspace/tmp'  # to tinker without sharing the results
 name: 'example_run'
+add_bkg: false  # add subtracted background to the cutouts
 
 # these are set by the code
 download_dir: !

--- a/configs/mer_catalog_targets/hayley_v1.yaml
+++ b/configs/mer_catalog_targets/hayley_v1.yaml
@@ -1,0 +1,42 @@
+base_dir: '/media/user/euclid-cutouts'
+name: 'v1'
+release_name: 'Q1_R1'
+sas_environment: 'PDR'  
+bands: ['VIS', 'NIR_Y']
+
+credentials_file: '/media/user/cred.txt' 
+
+num_tiles: 0  # all tiles
+refresh_catalogs: False
+
+download_method: 'datalabs_path'  # or sas
+delete_tiles: False
+debug: False
+run_async: True  # necessary for GZ selection_function
+max_retries: 5
+seed: 1
+
+# selection_cuts: space_warps
+selection_cuts: galaxy_zoo_generous
+field_of_view: galaxy_zoo  # or number in arcseconds
+# field_of_view: 15
+
+jpg_outputs: [
+  'gz_arcsinh_vis_only', 'gz_arcsinh_vis_y', 'gz_arcsinh_vis_lsb', 'sw_mtf_vis_y']   # typical GZ images
+  # 'sw_arcsinh_vis_only', 'sw_arcsinh_vis_y', 'sw_mtf_vis_only', 'sw_mtf_vis_y']  # and the similar SW ones as well (LAB+MTF especially might be useful)
+add_bkg: true
+fits_outputs: false
+overwrite_jpg: true
+overwrite_fits: false
+jpg_quality: 98
+use_fits_origin_for_jpg: true
+
+# ignore these
+download_dir: !
+tile_dir: !
+catalog_dir: ''
+cutout_dir: !
+jpg_dir: !
+fits_dir: !
+sanity_dir: !
+log_file: !


### PR DESCRIPTION
Euclid pipeline has two background subtraction steps: first by the instrument team, and then by the MER pipeline module. The MER background is on a smaller scale (much smaller than a tile) and might in principle affect extended galaxies. 

This PR (by Hayley) undoes the MER background subtraction by adding the subtracted background back onto the background-subtracted flux.

In practice, it seems to have extremely minimal effect on the images. The jpg images are identical and the FITS are very similar. 